### PR TITLE
Time-Stamp & EQ Name Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ API with the latest EQ information from [@pso2_emg_hour](http://twitter.com/pso2
 ```
 [
     {
-        time": "2017-08-29T01:05:04.000Z",
+        "time": "2017-08-29T01:05:04.000Z",
         "when": "2017-08-29T02:00:02.000Z",
         "eqs": [
             {

--- a/src/eqs.json
+++ b/src/eqs.json
@@ -41,7 +41,7 @@
 	"いざない": "Mothership",
 	"境界を破る闘将": "Lead Border-Breaker",
 	"降臨する星滅の災厄": "Advent of the Annihilator",
-	"狡猾なる黒翼の尖兵": "Dark Falz Loser",
+	"狡猾なる黒翼の尖兵": "Ebon-Winged Vanguard",
 	"ホワイトデーは大わらわ": "A Boisterous White Day",
 	"ワイルドイースター": "Wild Easter",
 	"平穏を引き裂く混沌": "Chaotic Tranquility",

--- a/src/index.js
+++ b/src/index.js
@@ -41,8 +41,8 @@ app.get('/eq', async (req, res) => {
     // Iterates over tweets and builds the result
     for (let tweet of tweets) {
         let dict = {
-            time: moment(tweet.created_at.substring(4), 'MMM DD HH:mm:ss ZZ YYYY'),
-            when: moment(tweet.created_at.substring(4), 'MMM DD HH:mm:ss ZZ YYYY').add(55, 'minutes').subtract(2, 'seconds')
+            time: moment(tweet.created_at.substring(4), 'MMM DD HH:mm:ss ZZ YYYY').utcOffset('+0900'),
+            when: moment(tweet.created_at.substring(4), 'MMM DD HH:mm:ss ZZ YYYY').utcOffset('+0900').add(55, 'minutes')
         };
 
         // Checks if the Tweet contains unscheduled EQs

--- a/src/index.js
+++ b/src/index.js
@@ -41,8 +41,8 @@ app.get('/eq', async (req, res) => {
     // Iterates over tweets and builds the result
     for (let tweet of tweets) {
         let dict = {
-            time: moment(tweet.created_at.substring(4), 'MMM DD HH:mm:ss ZZ YYYY').utcOffset('+0900').add(9, 'hours'),
-            when: moment(tweet.created_at.substring(4), 'MMM DD HH:mm:ss ZZ YYYY').add({ hours: 9 , minutes: 55}).subtract(2, 'seconds')
+            time: moment(tweet.created_at.substring(4), 'MMM DD HH:mm:ss ZZ YYYY'),
+            when: moment(tweet.created_at.substring(4), 'MMM DD HH:mm:ss ZZ YYYY').add(55, 'minutes').subtract(2, 'seconds')
         };
 
         // Checks if the Tweet contains unscheduled EQs


### PR DESCRIPTION
Both timings are off by 9 hours, and subtracting two seconds makes the time off on occasion. (Sometimes they're posted a second after the minute mark.) The EQ I fixed isn't used currently, but I thought it's double appearance was suspicious, so I compared with bumped.